### PR TITLE
feat: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,44 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+annotated-types = "==0.7.0"
+anyio = "==4.8.0"
+certifi = "==2025.1.31"
+cffi = "==1.17.1"
+charset-normalizer = "==3.4.1"
+click = "==8.1.8"
+cryptography = "==44.0.0"
+deprecated = "==1.2.18"
+fastapi = "==0.115.8"
+h11 = "==0.14.0"
+httpcore = "==1.0.7"
+httpx = "==0.28.1"
+idna = "==3.10"
+iniconfig = "==2.0.0"
+packaging = "==24.2"
+pluggy = "==1.5.0"
+pycparser = "==2.22"
+pydantic = "==2.10.6"
+pydantic-settings = "==2.7.1"
+pydantic-core = "==2.27.2"
+pygithub = "==2.5.0"
+pyjwt = "==2.10.1"
+pynacl = "==1.5.0"
+pytest = "==8.3.4"
+python-dotenv = "==1.0.1"
+requests = "==2.32.3"
+slack-sdk = "==3.34.0"
+sniffio = "==1.3.1"
+starlette = "==0.45.3"
+typing-extensions = "==4.12.2"
+urllib3 = "==2.3.0"
+uvicorn = "==0.34.0"
+wrapt = "==1.17.2"
+
+[dev-packages]
+
+[requires]
+python_version = "3.12"

--- a/api/router.py
+++ b/api/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from api.routes import books
+from api.routes import books_router
 
 api_router = APIRouter()
-api_router.include_router(books.router, prefix="/books", tags=["books"])
+api_router.include_router(books_router, prefix="/books", tags=["Books"])

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,0 +1,3 @@
+from .books import router as books_router
+
+__all__ = ["books_router"]

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,4 +1,5 @@
 from typing import OrderedDict
+from collections import OrderedDict as OrderedDictType
 
 from fastapi import APIRouter, status
 from fastapi.responses import JSONResponse
@@ -8,7 +9,7 @@ from api.db.schemas import Book, Genre, InMemoryDB
 router = APIRouter()
 
 db = InMemoryDB()
-db.books = {
+db.books = OrderedDictType({  # Preserve order in the dictionary
     1: Book(
         id=1,
         title="The Hobbit",
@@ -30,7 +31,7 @@ db.books = {
         publication_year=1955,
         genre=Genre.FANTASY,
     ),
-}
+})
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
@@ -41,22 +42,29 @@ async def create_book(book: Book):
     )
 
 
-@router.get(
-    "/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK
-)
+@router.get("/", response_model=OrderedDict[int, Book], status_code=status.HTTP_200_OK)
 async def get_books() -> OrderedDict[int, Book]:
-    return db.get_books()
+    return db.get_books()  
+
+#geting the book by id
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book_by_id(book_id: int):
+    if book_id not in db.books:
+        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content={"detail": "Book not found"})
+
+    return JSONResponse(status_code=status.HTTP_200_OK, content=db.books[book_id].model_dump())
 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
-async def update_book(book_id: int, book: Book) -> Book:
+async def update_book(book_id: int, book: Book):
+    updated_book = db.update_book(book_id, book)
     return JSONResponse(
         status_code=status.HTTP_200_OK,
-        content=db.update_book(book_id, book).model_dump(),
+        content=updated_book.model_dump(),
     )
 
 
 @router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_book(book_id: int) -> None:
+async def delete_book(book_id: int):
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)

--- a/main.py
+++ b/main.py
@@ -21,3 +21,4 @@ app.include_router(api_router, prefix=settings.API_PREFIX)
 async def health_check():
     """Checks if server is active."""
     return {"status": "active"}
+


### PR DESCRIPTION
## Description
- **Added Missing Endpoint:**  
  Implemented the `GET /api/v1/books/{book_id}` endpoint in `api/routes/books.py` to retrieve a book by its ID.  
  - If the book exists, it returns the book details as JSON.
  - If the book does not exist, it returns a 404 response with:
    ```json
    { "detail": "Book not found" }
    ```
- **CI/CD Pipeline Setup:**  
  - **CI Pipeline:** Configured a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs `pytest` on pull requests to the `main` branch.
  - **CD Pipeline:** Configured a separate GitHub Actions workflow (`.github/workflows/cd.yml`) that automatically deploys the latest changes to an Azure VM upon merging to the `main` branch.  
    - This deployment uses GitHub Secrets to securely authenticate via SSH.
    - The deployment script updates the app in `/var/www/fastapi-app`, activates the virtual environment, installs dependencies, and restarts the FastAPI service.
- **Nginx Integration:**  
  The application is served using Nginx as a reverse proxy to route traffic to the FastAPI backend.

## Testing
- Ran `pytest` locally and all tests passed.
- Manually verified the endpoint by testing:
  - **Valid ID:** Returns correct book details.
  - **Invalid ID:** Returns a 404 with `{"detail": "Book not found"}`.
- Confirmed that the CI pipeline runs on PR creation and that the CD pipeline deploys the app on merging to `main`.

## Related Task
- Stage 2: Deploy a FastAPI Application with CI/CD Pipeline

## Additional Notes
- The repository includes a well-structured `README.md` with setup and deployment instructions.
- The hng12-devbotops GitHub account has been added as a collaborator.
- The app is publicly accessible at [your-deployed-app-url] (without any paths).

## Checklist
- [x] Implemented the missing endpoint
- [x] Set up CI pipeline to run tests on pull requests
- [x] Configured CD pipeline to deploy on merging to `main`
- [x] Integrated Nginx as a reverse proxy
- [x] Verified the API functionality and deployment

